### PR TITLE
Added a command line option to select the desired export platforms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     compile 'com.squareup.okhttp:okhttp:2.6.0'
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'org.yaml:snakeyaml:1.16'
+    compile 'commons-cli:commons-cli:1.3.1'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:2.2.0'

--- a/src/main/java/de/bhurling/lyml/YmlParser.java
+++ b/src/main/java/de/bhurling/lyml/YmlParser.java
@@ -73,6 +73,10 @@ public class YmlParser {
     }
 
     public void createResources(boolean android, boolean ios, boolean windows, boolean java) throws IOException {
+        if (mDefaultLocale == null) {
+            System.out.println("Failed to load translations.");
+            return;
+        }
 
         // Fetch a list of (alphabetically sorted) keys from the default locale's set of translations
         ArrayList<String> keys = new ArrayList<>(mTranslations.get(mDefaultLocale.toString()).keySet());

--- a/src/main/java/de/bhurling/lyml/YmlParser.java
+++ b/src/main/java/de/bhurling/lyml/YmlParser.java
@@ -72,16 +72,27 @@ public class YmlParser {
         }
     }
 
-    public void createResources() throws IOException {
+    public void createResources(boolean android, boolean ios, boolean windows, boolean java) throws IOException {
 
         // Fetch a list of (alphabetically sorted) keys from the default locale's set of translations
         ArrayList<String> keys = new ArrayList<>(mTranslations.get(mDefaultLocale.toString()).keySet());
         Collections.sort(keys);
 
-        createAndroidResources(keys);
-        createIosResources(keys);
-        createWinPhoneResources(keys);
-        createJavaResources(keys);
+        if (android) {
+            createAndroidResources(keys);
+        }
+
+        if (ios) {
+            createIosResources(keys);
+        }
+
+        if (windows) {
+            createWinPhoneResources(keys);
+        }
+
+        if (java) {
+            createJavaResources(keys);
+        }
 
         System.out.println("\nDone. Have a look into\n\n" + mOutputDirectory.getAbsolutePath()
                 + "\n\nto find your files. Have a nice day!\n\n");


### PR DESCRIPTION
This PR adds the command line option --export (or -e) that accepts a comma separated list of output platforms (namely iOS, Android, Windows and Java). If the options is set, output is generated only for the selected platforms.